### PR TITLE
Add RxNorm Extesnion concept ids to the export code.

### DIFF
--- a/inst/sql/sql_server/AchillesHeel_v4.sql
+++ b/inst/sql/sql_server/AchillesHeel_v4.sql
@@ -201,7 +201,7 @@ WHERE or1.analysis_id IN (
 GROUP BY or1.analysis_id,
 	oa1.analysis_name;
 
---ruleid 13 drug exposure - 8 RxNorm
+--ruleid 13 drug exposure - 8 RxNorm/82 RxNorm Extension
 INSERT INTO @results_database_schema.ACHILLES_HEEL_results (
 	analysis_id,
 	ACHILLES_HEEL_warning,
@@ -223,7 +223,7 @@ WHERE or1.analysis_id IN (
 		)
 	AND or1.stratum_1 IS NOT NULL
 	AND c1.concept_id <> 0 
-  AND c1.vocabulary_id NOT IN (0,8)
+  AND c1.vocabulary_id NOT IN (0,8,82)
 GROUP BY or1.analysis_id,
 	oa1.analysis_name;
 

--- a/inst/sql/sql_server/export_v4/drug/sqlDrugTreemap.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlDrugTreemap.sql
@@ -28,10 +28,10 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from @vocab_database_schema.concept c1
 			inner join @vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 8
+			and c1.vocabulary_id in (8,82)
 			inner join @vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
-			and c2.vocabulary_id = 8
+			and c2.vocabulary_id in (8,82)
 			and c2.concept_class = 'Ingredient'
 		) rxnorm
 		left join
@@ -41,7 +41,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			inner join 
 			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 8
+			and c1.vocabulary_id in (8,82)
 			and c1.concept_class = 'Ingredient'
 			inner join 
 			@vocab_database_schema.concept c2

--- a/inst/sql/sql_server/export_v4/drugera/sqlDrugEraTreemap.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlDrugEraTreemap.sql
@@ -22,7 +22,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		select c1.concept_id as rxnorm_ingredient_concept_id, 
 			c1.concept_name as RxNorm_ingredient_concept_name
 		from @vocab_database_schema.concept c1
-		where c1.vocabulary_id = 8
+		where c1.vocabulary_id in (8,82)
 			and c1.concept_class = 'Ingredient'
 		) rxnorm
 		left join
@@ -32,7 +32,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			inner join 
 			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 8
+			and c1.vocabulary_id in (8,82)
 			and c1.concept_class = 'Ingredient'
 			inner join 
 			@vocab_database_schema.concept c2


### PR DESCRIPTION
Add RxNorm Extesnion concept ids to the export code.
In Achilles export code for CDM V5 drug concepts are filtered by domain, not by vocabulary id, so RxNorm Extension concepts are always included in the result, but they are missing in exported JSON for CDM V4 due to the condition 'vocabulary_id=8'.
Changed the condition to 'vocabulary_id in (8,82)', added RxNorm Extension to Achilles Heel report for V4.